### PR TITLE
Grows the stack as needed.

### DIFF
--- a/src/icu.ustring.c
+++ b/src/icu.ustring.c
@@ -357,6 +357,7 @@ static int icu_ustring_codepoint(lua_State *L) {
         if (ch == U_SENTINEL) {
             break;
         }
+        luaL_checkstack(L,1,"error growing the stack");
         lua_pushinteger(L,ch);
     }
     return lua_gettop(L)-1;

--- a/src/icu.utf8.c
+++ b/src/icu.utf8.c
@@ -270,6 +270,7 @@ static int icu_utf8_codepoint(lua_State *L) {
         if (ch == U_SENTINEL) {
             break;
         }
+        luaL_checkstack(L,1,"error growing the stack");
         lua_pushinteger(L,ch);
     }
     return lua_gettop(L)-1;


### PR DESCRIPTION
When Lua is compiled with LUA_USE_APICHECK, an error is detected in this two functions: `icu_utf8_codepoint` and `icu_ustring_codepoint` because they push stuff on the stack but they don't check if it is large enough.
