### PR TITLE
fix bracket pattern matching

### DIFF
--- a/src/matchengine.c
+++ b/src/matchengine.c
@@ -212,6 +212,7 @@ static int matchbracketclass(UChar32 sc, UCharIterator* pPattIter, uint32_t endc
 					return sig;
 				}
 				uiter_next32(pPattIter);
+				break;
 			case ']':
 				status = U_ZERO_ERROR;
 				uiter_setState(pPattIter, restore_state, &status);


### PR DESCRIPTION
Threre is the bug while iterating combinations in a set:
gsub("replace all spaces. and. dots.", "[%s%.]", "")
gsub remove only the first combination(%s). %. and and all of the following combinations are ignored.
