### PR TITLE
fix invalid codePoint=0x110000 in icu_utf8_char()

### DIFF
--- a/src/icu.utf8.c
+++ b/src/icu.utf8.c
@@ -365,16 +365,16 @@ static int icu_utf8_char(lua_State *L) {
             luaL_addchar(&buf, (char)(0x80 | ((codePoint >> 6) & 0x3F)));
             luaL_addchar(&buf, (char)(0x80 | (codePoint & 0x3F)));
         }
-        else if (codePoint > 0x110000) {
-            return luaL_argerror(L,i+1,"invalid codepoint");
-        }
-        else {
+        else if (codePoint < 0x110000) {
             // 00000000 000zzzzz yyyyyyyy xxxxxxxx
             // 11110zzz 10zzyyyy 10yyyyxx 10xxxxxx
             luaL_addchar(&buf, (char)(0xF0 | (codePoint >> 18)));
             luaL_addchar(&buf, (char)(0x80 | ((codePoint >> 12) & 0x3F)));
             luaL_addchar(&buf, (char)(0x80 | ((codePoint >> 6) & 0x3F)));
             luaL_addchar(&buf, (char)(0x80 | (codePoint & 0x3F)));
+        }
+        else {
+            return luaL_argerror(L,i+1,"invalid codepoint");
         }
     }
     luaL_pushresult(&buf);


### PR DESCRIPTION
The existing code only invalidates code points that are STRICTLY HIGHER than 0x110000; but 0x110000 itself is ALSO invalid.
The last test has reversed the order for test branches using ">" instead of "<" which is correct for all other tests (this could have used ">=", but it is more logical to reorder the branches in ascending order, and make the invalid codes handled in the last "else { }" branch.

This fixes bug #5 .